### PR TITLE
Increase the applications `blur_fix` interval

### DIFF
--- a/src/applications.js
+++ b/src/applications.js
@@ -26,7 +26,7 @@ var ApplicationsBlur = class ApplicationsBlur {
     this.windowActorBlurMap = new Map();
     this.pid = 0;
     this.override_map = {};
-    Utils.setInterval(() => this.fix_blur(), 1);
+    Utils.setInterval(() => this.fix_blur(), 16);
   }
   create_blur_actor(pid) {
     let wab = this.windowActorBlurMap.get(pid);


### PR DESCRIPTION
Hello, I just looked here (as this is going to get implemented in Blur my Shell as well, finally), and noticed that you fix your blur effects each 1ms, which is... a lot.

Considering that a 60Hz screen updates each 16.6ms, I guess fixing the blur every 16ms would be good enough? Ofc, there are a lot of improvements to be made (you can look at how blur my shell fixes this issue now, with nearly no artefacts and not very much CPU usage, in `paint_signals.js`), but this could at least decuple the performances of this extension.

By the way, maybe some day I will ask you how did you do to blur the onscreen keyboard effectively, I can't get to blur it the first time it opens! Blur that's another story :)